### PR TITLE
Add Filtering by Participant

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -10,3 +10,59 @@ footer {
     display: inline-block;
     margin-top: 20px;
 }
+
+/* Styling of Check-boxes :horizontal */
+.checkbox-inline, .radio-inline {
+    padding: 0;
+    padding-top: 5px;
+}
+
+.checkbox-inline + .checkbox-inline {
+  margin-left: 0;
+}
+.form-group input[type="checkbox"] {
+    display: none;
+}
+
+.form-group input[type="checkbox"] ~span {
+    background: #D1D3D4;
+    border-radius: 3px 3px 3px 3px;
+    color: #888;
+    border: 1px solid #D1D3D4;
+}
+
+.form-group input[type="checkbox"]:checked ~span {
+    color: #fff;
+    background-color: #337ab7;
+    border: 1px solid #337ab7;
+}
+
+.form-group input[type="checkbox"]:hover ~span {
+    border: 1px solid #666;
+    background-color: #4d8fcd;
+}
+
+.form-group input[type="checkbox"]:hover:not(:checked) ~span {
+    color: #666;
+    border: 1px solid #888;
+    background-color: #bbbdbe;
+}
+
+.checkbox-inline span {
+    display: inline-block;
+    width: 40px;
+    height: 30px;
+    text-align: center;
+    line-height: 30px;
+    cursor: pointer;
+}
+
+label {
+    margin-bottom: 0;
+    font-weight: normal;
+}
+
+#pidChooser {
+    text-align: right;
+    margin-right: 25px;
+}

--- a/server.R
+++ b/server.R
@@ -1,12 +1,43 @@
 library(dplyr)
-library(DT)
 library(ggplot2)
 library(shiny)
 library(plyr)
 
 # Define server function required to create the scatterplot
-shinyServer(function(input, output) {
+shinyServer(function(session, input, output) {
+
+  
+  pid_selection <- NULL
+  
+  #UpdateVisualizations: In this function all visualizations are defined.
+  UpdateVisualizations <- function() {
+    if (!is.null(pid_selection)) {
+      D <- D %>% filter(PID %in% pid_selection)
+    }
     
+    output$explorationPlot <- 
+      renderPlotly({
+        plot_ly(x = D[,input$Xaxis], y = D[,input$Yaxis]) %>% 
+          #add_trace(data = D, type = 'scatter') %>%
+          layout(xaxis = list(title = ~input$Xaxis), yaxis = list(title = ~input$Yaxis))
+      })
+    
+    output$timeExplorationPlot <- 
+      renderPlotly({
+        plot_ly(x = D[,"DateTime"], y = D[,input$timeYaxis]) %>% 
+          add_trace(data = D, type = 'scatter') %>%
+          layout(xaxis = list(title = "DateTime"), yaxis = list(title = ~input$timeYaxis))
+      }) 
+  }  
+  
+  
+  # Update PID Choosers to show PID numbers based on the data
+  participants <- unique(D %>% distinct(PID))
+  participants$PID[is.na(participants$PID)] <- "NA"
+  choices = setNames(c(1:nrow(participants)),participants$PID)
+  updateCheckboxGroupInput(session, label = "Filter by Participant:", "pidChooser", choices = choices, selected = NULL, inline = TRUE)
+  
+  
   # Create scatterplot object the plotOutput function is expecting
   #output$scatterplot <- renderPlot({
   #  df %>%
@@ -18,20 +49,24 @@ shinyServer(function(input, output) {
   #    labs(title = "La Baguette Data", x = "", y = "", color = "") +
   #    expand_limits(y = 0)
   #})
-  output$explorationPlot <- 
-    renderPlotly({
-      plot_ly(x = D[,input$Xaxis], y = D[,input$Yaxis]) %>% 
-      #add_trace(data = D, type = 'scatter') %>%
-      layout(xaxis = list(title = ~input$Xaxis), yaxis = list(title = ~input$Yaxis))
-    })
   
-  output$timeExplorationPlot <- 
-    renderPlotly({
-      plot_ly(x = D[,"DateTime"], y = D[,input$timeYaxis]) %>% 
-        add_trace(data = D, type = 'scatter') %>%
-        layout(xaxis = list(title = "DateTime"), yaxis = list(title = ~input$Yaxis))
-    }) 
+  observeEvent(ignoreNULL=FALSE, {input$pidChooser}, {
+    # prevent infinite loop - only update pid_selection to null, if the value is not already null.
+    if (is.null(pid_selection) & is.null(input$pidChooser)) {
+      return()
+    }
+    # CheckboxInputGroup sends an initial NULL value which overrides any query values.
+    # Make sure we check whether a specific PID was specified as URL param before.
+    else if (!is.null(input$pidChooser)) {
+      pid_selection <<- unlist(participants[input$pidChooser,"PID"])
+    } else {
+      pid_selection <<- NULL
+    }
+    print(paste("pid_selection",pid_selection))
+    UpdateVisualizations()
+  })
   
+  UpdateVisualizations()
   # Create data table
   #output$hovertable <- DT::renderDataTable({
   #  nearPoints(df, input$plot_hover) %>% 

--- a/ui.R
+++ b/ui.R
@@ -8,11 +8,15 @@ shinyUI(
     includeCSS("custom.css"),
     useShinyjs(),
     fluidRow(
-      titlePanel("Hand Strengthener Data Analysis"),
+      column(12, titlePanel("Hand Strengthener Data Analysis")),
       #column(4,
       #       column(1, style = "margin-top : 20px; text-align: right;", icon("user", class = "fa-2x", lib="font-awesome")),
       #       column(11,style = "margin-top : 20px; text-align: center;",selectInput("selectExperiment", NULL, choices = levels(M$Exp.ID)))
       #),
+    ),
+    fluidRow(
+      column(12, checkboxGroupInput("pidChooser", label = "Loading...", choices = NULL, inline = TRUE))
+    ),
       tabsetPanel(id = "tabs", type = "tabs",
         tabPanel(id = "explorepan", strong("Experiment Exploration"),
           sidebarPanel( 
@@ -50,7 +54,6 @@ shinyUI(
         )
       ),
       tags$footer()
-    )
   )
 )
 


### PR DESCRIPTION
Adds a widget which can be used to filter the data by participant.
![image](https://user-images.githubusercontent.com/3967945/74727449-7820f880-5241-11ea-952d-98d29124acca.png)

The filtering is only per PID currently, since we dont have the notion of e-mails in the HandStrengthener data yet.